### PR TITLE
continue on update cert errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
 
-update-ca-certificates
+update-ca-certificates || true
 
 # This ensures that kitchen errors are maintained when piped through sed
 set -o pipefail


### PR DESCRIPTION
since changing the user from `root` the certs fail to update on GitHub Actions. They don't need updating there, it is to support local running of the container on networks with inspection, so allow container to continue on error.

Example of error can be seen here:
https://github.com/dwp/terraform-aws-kong-gateway/pull/53/checks?check_run_id=2792113243