### PR TITLE
Set GitLab user and Personal Access Token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.7.3'
+ruby '2.7.5'
 source 'https://rubygems.org/' do
   gem 'kitchen-terraform', '~> 5.6'
 end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # github-action-kitchen-terraform
+
 GitHub Action to run Kitchen Terraform. Release versions match the Terraform version in use.
 
 After cloning this repo, please run:  
@@ -32,6 +33,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+          GITLAB_USER: ${{ secrets.GITLAB_USER }}
+          GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
       - name: Kitchen Test B
         uses: dwp/github-action-kitchen-terraform@v0.14.7
         with:
@@ -40,6 +43,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+          GITLAB_USER: ${{ secrets.GITLAB_USER }}
+          GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
 ```
 
 ### Docker Repo
@@ -49,16 +54,26 @@ The image repository can be found [here](https://quay.io/repository/dwp/kitchen-
 Use the Docker image to run an equivalent locally using the example commands below:
 
 Standard Kitchen command
+
 ```shell
 docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
 ```
 
+Kitchen command with GitLab user and GitLab Personal Access Token.
+Used when Terraform contains references to external modules that require Git credentials.
+
+```shell
+docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
+```
+
 Kitchen command with redacted output - output is piped to `sed` and the second argument is used to find/replace, this can be a string or regex
+
 ```shell
 docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a" "0123456789"
 ```
 
 Kitchen command with custom certificate trusts - mounts a local directory of certificates to trust
+
 ```shell
 docker run --rm -e AWS_PROFILE=default -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,21 @@ update-ca-certificates || true
 # This ensures that kitchen errors are maintained when piped through sed
 set -o pipefail
 
+if [ -n "$GITLAB_USER" ] && [ -n "$GITLAB_PAT" ]; then
+  # Set GitLab user
+  git config credential.https://gitlab.com.username ${GITLAB_USER}
+
+  # Configure small script to pass GitLab PAT from $GITLAB_PAT env var
+  # This avoids PAT being on disk, shell history, and terminal output
+  # See docs: https://git-scm.com/docs/gitcredentials#_requesting_credentials
+  GIT_ASKPASS=$(mktemp) && chmod a+rx $GIT_ASKPASS && export GIT_ASKPASS
+  cat > $GIT_ASKPASS <<'EOF'
+#!/bin/sh
+exec echo "$GITLAB_PAT"
+EOF
+
+fi
+
 if [ -z "$2" ]; then
   kitchen $1
 else


### PR DESCRIPTION
This Pull Request allows for a `GITLAB_USER` and `GITLAB_PAT` environment variable to be passed so that private repositories can be fetched using username/password authentication.