### PR TITLE
feat!: set Terraform version using Action input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # github-action-kitchen-terraform
 
-GitHub Action to run Kitchen Terraform. Release versions match the Terraform version in use.
+GitHub Action to run Kitchen Terraform.
 
 After cloning this repo, please run:  
 `make bootstrap`
@@ -12,6 +12,14 @@ This action runs [kitchen-terraform](https://github.com/newcontext-oss/kitchen-t
 ### `kitchen-command`
 
 **Required**. the command to follow the `kitchen` entrypoint e.g. `"test"` or `"test my-scenario"`
+
+### `aws-account-number`
+
+**Required**. AWS account number, used to redact from kitchen/terraform output
+
+### `terraform-version`
+
+**Required**. Terraform version to use. Supported versions (tags) listed [here](https://github.com/dwp/github-action-kitchen-terraform/pkgs/container/github-action-kitchen-terraform)
 
 ## Example usage
 
@@ -26,8 +34,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Kitchen Test A
-        uses: dwp/github-action-kitchen-terraform@v0.14.7
+        uses: dwp/github-action-kitchen-terraform@v2.0.0
         with:
+          terraform-version: "1.2.5"
           kitchen-command: "test scenario-a"
           aws-account-number: ${{ secrets.AWS_ACCOUNT }}
         env:
@@ -38,6 +47,7 @@ jobs:
       - name: Kitchen Test B
         uses: dwp/github-action-kitchen-terraform@v0.14.7
         with:
+          terraform-version: "1.2.5"
           kitchen-command: "test scenario-b"
           aws-account-number: ${{ secrets.AWS_ACCOUNT }}
         env:
@@ -49,31 +59,35 @@ jobs:
 
 ### Docker Repo
 
-The image repository can be found [here](https://quay.io/repository/dwp/kitchen-terraform).
+The image repository can be found on:
+
+* [Docker Hub](https://hub.docker.com/repository/docker/dwpdigital/kitchen-terraform)
+* [GitHub container registry](https://github.com/dwp/github-action-kitchen-terraform/pkgs/container/github-action-kitchen-terraform)
+* [Quay.io](https://quay.io/repository/dwp/kitchen-terraform)
 
 Use the Docker image to run an equivalent locally using the example commands below:
 
 Standard Kitchen command
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
 ```
 
 Kitchen command with GitLab user and GitLab Personal Access Token.
 Used when Terraform contains references to external modules that require Git credentials.
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
 ```
 
 Kitchen command with redacted output - output is piped to `sed` and the second argument is used to find/replace, this can be a string or regex
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a" "0123456789"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a" "0123456789"
 ```
 
 Kitchen command with custom certificate trusts - mounts a local directory of certificates to trust
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test scenario-a"
+docker run --rm -u root -e AWS_PROFILE=default -e CUSTOM_CA_DIR=/usr/share/ca-certificates/custom -v /etc/ssl/certs/:/usr/share/ca-certificates/custom -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,12 @@ inputs:
   aws-account-number:
     description: "AWS account number, used to redact from kitchen/terraform output"
     required: true
+  terraform-version:
+    description: "Terraform version to use. Supported versions (tags) listed here: https://github.com/dwp/github-action-kitchen-terraform/pkgs/container/github-action-kitchen-terraform"
+    required: true
 runs:
   using: "docker"
-  image: "docker://quay.io/dwp/kitchen-terraform:0.14.7"
+  image: docker://ghcr.io/${{ github.repository }}:${{ inputs.terraform-version }}
   args:
     - ${{ inputs.kitchen-command }}
     - ${{ inputs.aws-account-number }}


### PR DESCRIPTION
Previously, the Terraform version matched the Action version. The Action now has its own SemVer release, independent to the Terraform version in use. Container registry used switched from Quay.io to GitHub container registry. Documentation updated to reflect this and the recent changes around dock image build and publish jobs.

Signed-off-by: Daniel.Hill <daniel.hill@engineering.digital.dwp.gov.uk>