### PR TITLE
fix: use hardcoded container registry URI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://ghcr.io/${{ github.repository }}:${{ inputs.terraform-version }}
+  image: docker://ghcr.io/dwp/github-action-kitchen-terraform:${{ inputs.terraform-version }}
   args:
     - ${{ inputs.kitchen-command }}
     - ${{ inputs.aws-account-number }}


### PR DESCRIPTION
When testing it was found that the `github` object used in `github.repository` isn't available at this point, so switching to hardcoded value instead.

Signed-off-by: Daniel.Hill <daniel.hill@engineering.digital.dwp.gov.uk>