### PR TITLE
feat!: use tfenv to manage Terraform versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,14 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - kics-scan
-    strategy:
-      matrix:
-        terraform_version:
-          - 0.14.7
-          - 1.2.4
-          - 1.2.5
-        ruby_version:
-          - 3.1.2
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
@@ -51,29 +43,44 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and export to Docker
+      - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
-          load: true
-          push: false
-          build-args: |
-            RUBY_VERSION=${{ matrix.ruby_version }}
-            TERRAFORM_VERSION=${{ matrix.terraform_version }}
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}-edge
-
-      - name: Test
-        run: docker run --rm -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}-edge "converge"
-      - name: Test container [kitchen verify]
-        run: docker run --rm -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}-edge "verify"
-
-      - name: Push to registries
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
           push: true
           build-args: |
-            RUBY_VERSION=${{ matrix.ruby_version }}
-            TERRAFORM_VERSION=${{ matrix.terraform_version }}
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}-edge
+            RUBY_VERSION=3.1.2
+            TERRAFORM_VERSIONS=0.14.7 1.2.4 1.2.5
+          tags: ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }}
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      matrix:
+        terraform_version:
+          - 0.14.7
+          - 1.2.4
+          - 1.2.5
+        ruby_version:
+          - 3.1.2
+    env:
+      TFENV_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test container [kitchen converge]
+        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }} "converge"
+      - name: Test container [kitchen verify]
+        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }} "verify"
+

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,20 +1,11 @@
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 name: publish-containers
 jobs:
   publish-containers:
     name: Build & Publish Containers
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        terraform_version:
-          - 0.14.7
-          - 1.2.4
-          - 1.2.5
-        ruby_version:
-          - 3.1.2
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
@@ -43,28 +34,11 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          load: true
-          push: false
-          build-args: |
-            RUBY_VERSION=${{ matrix.ruby_version }}
-            TERRAFORM_VERSION=${{ matrix.terraform_version }}
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}
-
-      - name: Test container [kitchen converge]
-        run: docker run --rm -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }} "converge"
-      - name: Test container [kitchen verify]
-        run: docker run --rm -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }} "verify"
-
-      - name: Push to registries
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
           push: true
           build-args: |
-            RUBY_VERSION=${{ matrix.ruby_version }}
-            TERRAFORM_VERSION=${{ matrix.terraform_version }}
+            RUBY_VERSION=3.1.2
+            TERRAFORM_VERSIONS=0.14.7 1.2.4 1.2.5
           tags: |
-            ghcr.io/${{ github.repository }}:${{ matrix.terraform_version }}
-            quay.io/dwp/kitchen-terraform:${{ matrix.terraform_version }}
-            dwpdigital/kitchen-terraform:${{ matrix.terraform_version }}
+            ghcr.io/${{ github.repository }}:${{ github.ref }}
+            quay.io/dwp/kitchen-terraform:${{ github.ref }}
+            dwpdigital/kitchen-terraform:${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ After cloning this repo, please run:
 
 This action runs [kitchen-terraform](https://github.com/newcontext-oss/kitchen-terraform) to test Terraform modules.
 
+The Action (and container) uses [tfenv](https://github.com/tfutils/tfenv) to manage Terraform versions.
+
 ## Inputs
 
 ### `kitchen-command`
@@ -19,7 +21,7 @@ This action runs [kitchen-terraform](https://github.com/newcontext-oss/kitchen-t
 
 ### `terraform-version`
 
-**Required**. Terraform version to use. Supported versions (tags) listed [here](https://github.com/dwp/github-action-kitchen-terraform/pkgs/container/github-action-kitchen-terraform)
+**Required**. Terraform version to use. Tested versions listed [here](.github/workflows/build.yaml#L63). Any version can be used (including alpha and beta releases), `tfenv` will install the specified version. Pre-installed versions listed [here](.github/workflows/publish-containers.yml#L53)
 
 ## Example usage
 
@@ -45,7 +47,7 @@ jobs:
           GITLAB_USER: ${{ secrets.GITLAB_USER }}
           GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
       - name: Kitchen Test B
-        uses: dwp/github-action-kitchen-terraform@v0.14.7
+        uses: dwp/github-action-kitchen-terraform@v2.0.0
         with:
           terraform-version: "1.2.5"
           kitchen-command: "test scenario-b"
@@ -70,24 +72,24 @@ Use the Docker image to run an equivalent locally using the example commands bel
 Standard Kitchen command
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
 ```
 
 Kitchen command with GitLab user and GitLab Personal Access Token.
 Used when Terraform contains references to external modules that require Git credentials.
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
 ```
 
 Kitchen command with redacted output - output is piped to `sed` and the second argument is used to find/replace, this can be a string or regex
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a" "0123456789"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a" "0123456789"
 ```
 
 Kitchen command with custom certificate trusts - mounts a local directory of certificates to trust
 
 ```shell
-docker run --rm -u root -e AWS_PROFILE=default -e CUSTOM_CA_DIR=/usr/share/ca-certificates/custom -v /etc/ssl/certs/:/usr/share/ca-certificates/custom -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:1.2.5 "test scenario-a"
+docker run --rm -u root -e AWS_PROFILE=default -e CUSTOM_CA_DIR=/usr/share/ca-certificates/custom -v /etc/ssl/certs/:/usr/share/ca-certificates/custom -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,9 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://ghcr.io/dwp/github-action-kitchen-terraform:${{ inputs.terraform-version }}
+  image: "docker://ghcr.io/dwp/github-action-kitchen-terraform:2.0.0"
+  env:
+    TFENV_TERRAFORM_VERSION: ${{ inputs.terraform-version}}
   args:
     - ${{ inputs.kitchen-command }}
     - ${{ inputs.aws-account-number }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ -n "$CUSTOM_CA_DIR" ]; then
   cp ${CUSTOM_CA_DIR}/* /etc/ssl/certs/
-  update-ca-certificates
+  update-ca-certificates --fresh
 fi
 
 # This ensures that kitchen errors are maintained when piped through sed


### PR DESCRIPTION
Instead of creating a single version of Terraform per container and release, instead releases will follow semver. Containers will be tagged with the release number. GitHub Action will allow user to specify the Terraform version to use, some of which are pre-installed and some are tested, but tfenv will install and use any version at runtime.