### PR TITLE
fix: build containers on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
           build-args: |
             RUBY_VERSION=3.1.2
             TERRAFORM_VERSIONS=0.14.7 1.2.4 1.2.5
-          tags: ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }}
+          tags: ghcr.io/${{ github.repository }}:rc-${{ github.head_ref }}
 
   test:
     name: test
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test container [kitchen converge]
-        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }} "converge"
+        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.head_ref }} "converge"
       - name: Test container [kitchen verify]
-        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.base_ref }} "verify"
+        run: docker run --rm -e TFENV_TERRAFORM_VERSION=${TFENV_TERRAFORM_VERSION} -v "$(pwd)/examples/check-container":/usr/action ghcr.io/${{ github.repository }}:rc-${{ github.head_ref }} "verify"
 

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,6 +1,9 @@
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      - '.release-please-manifest.json'
 name: publish-containers
 jobs:
   publish-containers:
@@ -9,6 +12,17 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
+
+      - name: Get release number
+        id: get-release
+        run: |
+          RELEASE=$(sed 's/"."/"key"/g' .release-please-manifest.json | jq -r .key)
+          echo ${RELEASE}
+          echo ::set-output name=release-number::${RELEASE}
+
+      - name: Show version
+        run: |
+          echo "Version: ${{ steps.get-release.outputs.release-number }}"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -39,6 +53,6 @@ jobs:
             RUBY_VERSION=3.1.2
             TERRAFORM_VERSIONS=0.14.7 1.2.4 1.2.5
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref }}
-            quay.io/dwp/kitchen-terraform:${{ github.ref }}
-            dwpdigital/kitchen-terraform:${{ github.ref }}
+            ghcr.io/${{ github.repository }}:${{ steps.get-release.outputs.release-number }}
+            quay.io/dwp/kitchen-terraform:${{ steps.get-release.outputs.release-number }}
+            dwpdigital/kitchen-terraform:${{ steps.get-release.outputs.release-number }}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Kitchen Test A
-        uses: dwp/github-action-kitchen-terraform@v2.0.0
+        uses: dwp/github-action-kitchen-terraform@v2.0.1
         with:
           terraform-version: "1.2.5"
           kitchen-command: "test scenario-a"
@@ -47,7 +47,7 @@ jobs:
           GITLAB_USER: ${{ secrets.GITLAB_USER }}
           GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
       - name: Kitchen Test B
-        uses: dwp/github-action-kitchen-terraform@v2.0.0
+        uses: dwp/github-action-kitchen-terraform@v2.0.1
         with:
           terraform-version: "1.2.5"
           kitchen-command: "test scenario-b"
@@ -72,24 +72,24 @@ Use the Docker image to run an equivalent locally using the example commands bel
 Standard Kitchen command
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.1 "test scenario-a"
 ```
 
 Kitchen command with GitLab user and GitLab Personal Access Token.
 Used when Terraform contains references to external modules that require Git credentials.
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
+docker run --rm -e AWS_PROFILE=default -e GITLAB_USER=user.name -e GITLAB_PAT=token -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.1 "test scenario-a"
 ```
 
 Kitchen command with redacted output - output is piped to `sed` and the second argument is used to find/replace, this can be a string or regex
 
 ```shell
-docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a" "0123456789"
+docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/kitchen/.aws quay.io/dwp/kitchen-terraform:2.0.1 "test scenario-a" "0123456789"
 ```
 
 Kitchen command with custom certificate trusts - mounts a local directory of certificates to trust
 
 ```shell
-docker run --rm -u root -e AWS_PROFILE=default -e CUSTOM_CA_DIR=/usr/share/ca-certificates/custom -v /etc/ssl/certs/:/usr/share/ca-certificates/custom -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:2.0.0 "test scenario-a"
+docker run --rm -u root -e AWS_PROFILE=default -e CUSTOM_CA_DIR=/usr/share/ca-certificates/custom -v /etc/ssl/certs/:/usr/share/ca-certificates/custom -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:2.0.1 "test scenario-a"
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/dwp/github-action-kitchen-terraform:2.0.0"
+  image: "docker://ghcr.io/dwp/github-action-kitchen-terraform:2.0.1"
   env:
     TFENV_TERRAFORM_VERSION: ${{ inputs.terraform-version}}
   args:


### PR DESCRIPTION
Releases are created by the bot, which doesn't trigger the release flow, so instead this will trigger on manifest changing. You can view test runs on my forked repo. Action and README updated to prempt the new version number. Ref corrected for PR container tags

Signed-off-by: Daniel Hill <dan@mamu.co>